### PR TITLE
Add exclusion for guava-jdk5 artifact, a transitive dependency of google-api-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,12 @@
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
       <version>${google.api.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava-jdk5</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.oauth-client</groupId>


### PR DESCRIPTION
See #63