### PR TITLE
Added deletecallset command and test.

### DIFF
--- a/src/main/java/com/google/cloud/genomics/api/client/CommandLine.java
+++ b/src/main/java/com/google/cloud/genomics/api/client/CommandLine.java
@@ -74,6 +74,7 @@ class CommandLine {
 
     addCommand("searchcallsets", new SearchCallSetsCommand());
     addCommand("updatecallset", new UpdateCallSetCommand());
+    addCommand("deletecallset", new DeleteCallSetCommand());
 
     addCommand("listjobs", new ListJobsCommand());
     addCommand("getjob", new GetJobsCommand());

--- a/src/main/java/com/google/cloud/genomics/api/client/commands/DeleteCallSetCommand.java
+++ b/src/main/java/com/google/cloud/genomics/api/client/commands/DeleteCallSetCommand.java
@@ -1,0 +1,37 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.google.cloud.genomics.api.client.commands;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.google.api.services.genomics.Genomics;
+
+import java.io.IOException;
+
+@Parameters(commandDescription = "Deletes a call set by ID")
+public class DeleteCallSetCommand extends BaseCommand {
+
+  @Parameter(names = "--call_set_id",
+      description = "The ID of the call set to delete.",
+      required = true)
+  public String callSetId;
+
+  @Override
+  public void handleRequest(Genomics genomics) throws IOException {
+    genomics.callsets().delete(callSetId).execute();
+    System.out.println("Deleted call set: " + callSetId);
+  }
+}

--- a/src/test/java/com/google/cloud/genomics/api/client/commands/CommandTest.java
+++ b/src/test/java/com/google/cloud/genomics/api/client/commands/CommandTest.java
@@ -31,7 +31,8 @@ public abstract class CommandTest {
   @Mock protected Genomics.Callsets callsets;
   @Mock protected Genomics.Callsets.Search callsetSearch;
   @Mock protected Genomics.Callsets.Patch callsetPatch;
-
+  @Mock protected Genomics.Callsets.Delete callsetDelete;
+  
   @Mock protected Genomics.Datasets datasets;
   @Mock protected Genomics.Datasets.Create datasetCreate;
   @Mock protected Genomics.Datasets.Get datasetGet;

--- a/src/test/java/com/google/cloud/genomics/api/client/commands/DeleteCallSetCommandTest.java
+++ b/src/test/java/com/google/cloud/genomics/api/client/commands/DeleteCallSetCommandTest.java
@@ -1,0 +1,41 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.google.cloud.genomics.api.client.commands;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+@RunWith(JUnit4.class)
+public class DeleteCallSetCommandTest extends CommandTest {
+
+  @Test
+  public void testDeleteCallSet() throws Exception {
+    DeleteCallSetCommand command = new DeleteCallSetCommand();
+    command.callSetId = "cs1";
+
+    Mockito.when(callsets.delete("cs1")).thenReturn(callsetDelete);
+
+    command.handleRequest(genomics);
+
+    String output = outContent.toString();
+    assertTrue(output, output.contains("Deleted call set: cs1"));
+  }
+
+}


### PR DESCRIPTION
Added deletecallset command to the Java api client and command line.  This enables deletion of callsets by ID from the command line.