### PR TITLE
Create variantset command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-genomics</artifactId>
-      <version>v1beta2-rev45-1.20.0</version>
+      <version>v1beta2-rev54-1.20.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.genomics</groupId>

--- a/src/main/java/com/google/cloud/genomics/api/client/commands/CreateVariantSetCommand.java
+++ b/src/main/java/com/google/cloud/genomics/api/client/commands/CreateVariantSetCommand.java
@@ -15,12 +15,9 @@ limitations under the License.
 */
 package com.google.cloud.genomics.api.client.commands;
 
-import com.google.api.client.util.Joiner;
 import com.google.api.services.genomics.Genomics;
 import com.google.api.services.genomics.GenomicsScopes;
 import com.google.api.services.genomics.model.Dataset;
-import com.google.api.services.genomics.model.ImportVariantsRequest;
-import com.google.api.services.genomics.model.Job;
 import com.google.api.services.genomics.model.VariantSet;
 
 import com.beust.jcommander.Parameter;
@@ -36,7 +33,7 @@ import java.util.List;
 public class CreateVariantSetCommand extends BaseCommand {
 
   @Parameter(names = "--dataset_id",
-      description = "The Genomics API dataset ID to create into.",
+      description = "The dataset ID in which to create the new variant set.",
       required = true)
   public String datasetId;
 
@@ -55,7 +52,7 @@ public class CreateVariantSetCommand extends BaseCommand {
     if (dataset == null) {
       return;
     }
-    System.out.println("Creating variant set into: " + dataset.getName() +" (id: " + datasetId + ")");
+    System.out.println("Creating variant set in dataset: " + dataset.getName() +" (id: " + datasetId + ")");
 
     VariantSet variantSet = new VariantSet().setDatasetId(datasetId);
 

--- a/src/main/java/com/google/cloud/genomics/api/client/commands/CreateVariantSetCommand.java
+++ b/src/main/java/com/google/cloud/genomics/api/client/commands/CreateVariantSetCommand.java
@@ -1,0 +1,66 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.google.cloud.genomics.api.client.commands;
+
+import com.google.api.client.util.Joiner;
+import com.google.api.services.genomics.Genomics;
+import com.google.api.services.genomics.GenomicsScopes;
+import com.google.api.services.genomics.model.Dataset;
+import com.google.api.services.genomics.model.ImportVariantsRequest;
+import com.google.api.services.genomics.model.Job;
+import com.google.api.services.genomics.model.VariantSet;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Creates a new variant set (initially empty).
+*/
+@Parameters(commandDescription = "Create a new (empty) variant set")
+public class CreateVariantSetCommand extends BaseCommand {
+
+  @Parameter(names = "--dataset_id",
+      description = "The Genomics API dataset ID to create into.",
+      required = true)
+  public String datasetId;
+
+  @Override
+  public List<String> getScopes() {
+    List<String> scopes = super.getScopes();
+    scopes.add(GenomicsScopes.DEVSTORAGE_READ_WRITE);
+    return scopes;
+  }
+
+  @Override
+  public void handleRequest(Genomics genomics) throws IOException {
+
+    // Get the name
+    Dataset dataset = getDataset(genomics, datasetId);
+    if (dataset == null) {
+      return;
+    }
+    System.out.println("Creating variant set into: " + dataset.getName() +" (id: " + datasetId + ")");
+
+    VariantSet variantSet = new VariantSet().setDatasetId(datasetId);
+
+    VariantSet ret = genomics.variantsets().create(variantSet).execute();
+
+    System.out.println("Created variant set id: "+ret.getId());
+  }
+}

--- a/src/test/java/com/google/cloud/genomics/api/client/commands/CommandTest.java
+++ b/src/test/java/com/google/cloud/genomics/api/client/commands/CommandTest.java
@@ -64,6 +64,7 @@ public abstract class CommandTest {
   @Mock protected Genomics.Readgroupsets.Search readsetSearch;
 
   @Mock protected Genomics.Variantsets variantSets;
+  @Mock protected Genomics.Variantsets.Create variantSetCreate;
   @Mock protected Genomics.Variantsets.Get variantSetGet;
   @Mock protected Genomics.Variantsets.Export variantExport;
   @Mock protected Genomics.Variantsets.ImportVariants variantImport;

--- a/src/test/java/com/google/cloud/genomics/api/client/commands/CreateVariantSetCommandTest.java
+++ b/src/test/java/com/google/cloud/genomics/api/client/commands/CreateVariantSetCommandTest.java
@@ -1,0 +1,58 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.google.cloud.genomics.api.client.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.api.client.util.store.MemoryDataStoreFactory;
+import com.google.api.services.genomics.model.Dataset;
+import com.google.api.services.genomics.model.VariantSet;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+import java.util.Map;
+
+@RunWith(JUnit4.class)
+public class CreateVariantSetCommandTest extends CommandTest {
+
+  @Test
+  public void testCreateVariantSet() throws Exception {
+    CreateVariantSetCommand command = new CreateVariantSetCommand();
+    command.datasetId = "dsid";
+    command.setDataStoreFactory(new MemoryDataStoreFactory());
+
+    Dataset dataset1 = new Dataset().setId("dsid").setName("name1");
+
+    Mockito.when(datasets.get("dsid")).thenReturn(datasetGet);
+    Mockito.when(datasetGet.execute()).thenReturn(dataset1);
+
+    VariantSet expectedVariantSet = new VariantSet().setDatasetId("dsid");
+    VariantSet responseVariantSet = new VariantSet().setDatasetId("dsid").setId("shiny");
+
+    Mockito.when(variantSets.create(expectedVariantSet)).thenReturn(variantSetCreate);
+    Mockito.when(variantSetCreate.execute()).thenReturn(responseVariantSet);
+
+    command.handleRequest(genomics);
+
+    String output = outContent.toString();
+    assertTrue(output, output.contains("Created variant set id: shiny"));
+  }
+
+}


### PR DESCRIPTION
Added support for [variantset create](https://cloud.google.com/genomics/reference/rest/v1/variantsets/create). This call is optional in v1b2 (it creates one automatically for you, but you're limited to a single variantset per dataset), but required in v1 (you can have as many variantsets per dataset as you want).
